### PR TITLE
[Feat] 일주일 소확행 미실천 알림 구현

### DIFF
--- a/src/main/java/com/guttery/madii/domain/achievement/application/service/JoyPlaylistService.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/application/service/JoyPlaylistService.java
@@ -33,7 +33,6 @@ public class JoyPlaylistService {
         final User user = UserServiceHelper.findExistingUser(userRepository, userPrincipal);
         final Joy joy = JoyServiceHelper.findExistingJoy(joyRepository, addAchievementRequest.joyId());
         final Achievement newAchievement = Achievement.create(user, joy, FinishInfo.createNotFinished());
-        // TODO: 중복 추가 방지를 위한 로직 필요 -> 테스트 이후에 구현 (복합 unique key 고려 중)
 
         achievementRepository.save(newAchievement);
     }

--- a/src/main/java/com/guttery/madii/domain/achievement/domain/repository/AchievementQueryDslRepository.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/domain/repository/AchievementQueryDslRepository.java
@@ -3,6 +3,7 @@ package com.guttery.madii.domain.achievement.domain.repository;
 import com.guttery.madii.domain.achievement.application.dto.CalenderAchievementColorResponse;
 import com.guttery.madii.domain.achievement.application.dto.CalenderDailyJoyAchievementResponse;
 import com.guttery.madii.domain.achievement.application.dto.JoyPlaylistResponse;
+import com.guttery.madii.domain.achievement.domain.model.Achievement;
 
 import java.time.LocalDate;
 
@@ -12,4 +13,7 @@ public interface AchievementQueryDslRepository {
     CalenderAchievementColorResponse getAchievementsInCalender(Long userId, LocalDate startDate, LocalDate endDate);
 
     CalenderDailyJoyAchievementResponse getDailyJoyAchievementInfos(Long userId, LocalDate date);
+
+    Achievement getJoyAlreadyInPlaylist(Long userId, Long joyId, LocalDate date);
+
 }

--- a/src/main/java/com/guttery/madii/domain/achievement/infrastructure/AchievementRepositoryImpl.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/infrastructure/AchievementRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.guttery.madii.domain.achievement.application.dto.DailyJoyAchievementI
 import com.guttery.madii.domain.achievement.application.dto.DailyJoyPlaylist;
 import com.guttery.madii.domain.achievement.application.dto.JoyAchievementInfo;
 import com.guttery.madii.domain.achievement.application.dto.JoyPlaylistResponse;
+import com.guttery.madii.domain.achievement.domain.model.Achievement;
 import com.guttery.madii.domain.achievement.domain.repository.AchievementQueryDslRepository;
 import com.guttery.madii.domain.achievement.domain.repository.AchievementRepository;
 import com.querydsl.core.types.Projections;
@@ -109,5 +110,17 @@ public class AchievementRepositoryImpl extends BaseQueryDslRepository<Achievemen
                 .fetch();
 
         return new CalenderDailyJoyAchievementResponse(dailyJoyAchievementInfos);
+    }
+
+    @Override
+    public Achievement getJoyAlreadyInPlaylist(Long userId, Long joyId, LocalDate date) {
+        return select(achievement)
+                .from(achievement)
+                .join(achievement.joy, joy)
+                .fetchJoin()
+                .join(achievement.achiever, user)
+                .fetchJoin()
+                .where(achievement.achiever.userId.eq(userId), joy.joyId.eq(joyId), achievement.createdAt.between(date.atStartOfDay().plusHours(TODAY_PLAYLIST_TIME_OFFSET), date.atStartOfDay().plusDays(1).minusSeconds(1).plusHours(TODAY_PLAYLIST_TIME_OFFSET)))
+                .fetchFirst();
     }
 }

--- a/src/main/java/com/guttery/madii/domain/notification/application/service/NoJoyAchievementsNotificationSendService.java
+++ b/src/main/java/com/guttery/madii/domain/notification/application/service/NoJoyAchievementsNotificationSendService.java
@@ -1,0 +1,80 @@
+package com.guttery.madii.domain.notification.application.service;
+
+import com.guttery.madii.domain.notification.application.dto.FlattedNotificationTokenDto;
+import com.guttery.madii.domain.notification.application.dto.MessageData;
+import com.guttery.madii.domain.notification.application.dto.NotificationData;
+import com.guttery.madii.domain.notification.domain.model.Notification;
+import com.guttery.madii.domain.notification.domain.repository.NotificationRepository;
+import com.guttery.madii.domain.notification.domain.repository.NotificationTokensRepository;
+import com.guttery.madii.domain.notification.domain.service.NotificationClient;
+import com.guttery.madii.domain.user.domain.model.User;
+import com.guttery.madii.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class NoJoyAchievementsNotificationSendService {
+    private static final int DAY_CRITERIA = 7;
+    private static final String NO_JOY_ACHIEVEMENT_NOTIFICATION_TITLE = "오늘의 행복이 %s님을 기다리고 있어요";
+    private static final String NO_JOY_ACHIEVEMENT_NOTIFICATION_MESSAGE = "마지막으로 소확행을 실천한 지 일주일이 지났어요. 오늘 이어서 실천해 보시는 건 어때요?";
+
+    private final UserRepository userRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationTokensRepository notificationTokensRepository;
+    private final NotificationClient notificationClient;
+
+    @Scheduled(cron = "0 0 20 * * SUN") // 매주 일요일 오후 8시에 실행
+    @Transactional
+    public void sendNoJoyAchievementsNotifications() {
+        final List<User> foundUsers = getUsersWithNoJoyAchievements();
+        final List<FlattedNotificationTokenDto> flattedNotificationTokenDtos = notificationTokensRepository.getAllFlatted();
+        sendNotifications(foundUsers, flattedNotificationTokenDtos);
+        saveNotifications(createNotificationData());
+    }
+
+    private List<User> getUsersWithNoJoyAchievements() {
+        return userRepository.findUsersWithNoJoyAchievementsForDays(DAY_CRITERIA);
+    }
+
+    private void sendNotifications(
+            final List<User> users,
+            final List<FlattedNotificationTokenDto> flattedNotificationTokenDtos) {
+
+        final Map<String, List<String>> tokensByUserId = flattedNotificationTokenDtos.stream()
+                .collect(Collectors.toMap(FlattedNotificationTokenDto::userId, FlattedNotificationTokenDto::tokens));
+
+        final List<MessageData> messageDatas = users.stream()
+                .filter(User::hasProfile)
+                .flatMap(user -> tokensByUserId.getOrDefault(user.getUserId().toString(), Collections.emptyList()).stream()
+                        .map(token -> createMessageData(String.format(NO_JOY_ACHIEVEMENT_NOTIFICATION_TITLE, user.getNickname()), token))
+                ).toList();
+
+        notificationClient.sendDifferentNotificationForUsers(messageDatas);
+    }
+
+    private MessageData createMessageData(final String contents, final String token) {
+        return new MessageData(contents, NO_JOY_ACHIEVEMENT_NOTIFICATION_MESSAGE, token);
+    }
+
+    private NotificationData createNotificationData() {
+        return new NotificationData(NO_JOY_ACHIEVEMENT_NOTIFICATION_TITLE, NO_JOY_ACHIEVEMENT_NOTIFICATION_MESSAGE);
+    }
+
+    private void saveNotifications(final NotificationData notificationData) {
+        final List<User> allUsers = userRepository.findAll();
+
+        notificationRepository.bulkSave(
+                Notification.createdBulkFormatted(allUsers, notificationData.title(), NO_JOY_ACHIEVEMENT_NOTIFICATION_MESSAGE)
+        );
+    }
+}

--- a/src/main/java/com/guttery/madii/domain/notification/domain/model/Notification.java
+++ b/src/main/java/com/guttery/madii/domain/notification/domain/model/Notification.java
@@ -52,6 +52,13 @@ public class Notification {
                 .toList();
     }
 
+    public static List<Notification> createdBulkFormatted(List<User> users, String title, String formattedContents) {
+        return users.stream()
+                .filter(User::hasProfile)
+                .map(user -> new Notification(user, title, String.format(formattedContents, user.getNickname()), false))
+                .toList();
+    }
+
     public static List<Notification> createdBulkFormatted(List<User> users, String title, String joyName, String formattedContents) {
         return users.stream()
                 .filter(User::hasProfile)

--- a/src/main/java/com/guttery/madii/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/guttery/madii/domain/notification/presentation/NotificationController.java
@@ -2,6 +2,7 @@ package com.guttery.madii.domain.notification.presentation;
 
 import com.guttery.madii.domain.notification.application.dto.NotificationListResponse;
 import com.guttery.madii.domain.notification.application.dto.SaveTokenRequest;
+import com.guttery.madii.domain.notification.application.service.NoJoyAchievementsNotificationSendService;
 import com.guttery.madii.domain.notification.application.service.NotificationQueryService;
 import com.guttery.madii.domain.notification.application.service.NotificationTokenService;
 import com.guttery.madii.domain.notification.application.service.TodayJoyNotificationSendService;
@@ -32,6 +33,7 @@ public class NotificationController {
     private final NotificationQueryService notificationQueryService;
     private final TodayJoyNotificationSendService todayJoyNotificationSendService;
     private final UnfinishedAchievementNotificationSendService unfinishedAchievementNotificationSendService;
+    private final NoJoyAchievementsNotificationSendService noJoyAchievementsNotificationSendService;
 
     @PostMapping("/token")
     @ApiResponses(
@@ -97,5 +99,20 @@ public class NotificationController {
     @Operation(summary = "플레이리스트 미완료 알림 발송 테스트 API", description = "플레이리스트 미완료 알림 발송 테스트 API입니다.")
     public void sendPlaylistNotification() {
         unfinishedAchievementNotificationSendService.sendUnfinishedAchievementNotifications();
+    }
+
+    @PostMapping("/test/no-joy")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "플레이리스트 알림 발송 성공",
+                            useReturnTypeSchema = true
+                    )
+            }
+    )
+    @Operation(summary = "플레이리스트 미완료 알림 발송 테스트 API", description = "플레이리스트 미완료 알림 발송 테스트 API입니다.")
+    public void sendNoJoyAchievementsNotification() {
+        noJoyAchievementsNotificationSendService.sendNoJoyAchievementsNotifications();
     }
 }

--- a/src/main/java/com/guttery/madii/domain/user/domain/repository/UserQueryDslRepository.java
+++ b/src/main/java/com/guttery/madii/domain/user/domain/repository/UserQueryDslRepository.java
@@ -20,4 +20,6 @@ public interface UserQueryDslRepository {
     BeforeWithdrawInfoResponse getBeforeWithdrawInfo(Long userId, LocalDateTime now);
 
     List<User> findUsersWithUnfinishedAchievements(LocalDateTime dateTime);
+
+    List<User> findUsersWithNoJoyAchievementsForDays(int days);
 }

--- a/src/main/java/com/guttery/madii/domain/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/guttery/madii/domain/user/infrastructure/UserRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.guttery.madii.domain.user.domain.model.User;
 import com.guttery.madii.domain.user.domain.repository.UserQueryDslRepository;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
@@ -87,5 +88,19 @@ public class UserRepositoryImpl extends BaseQueryDslRepository<User> implements 
                 .fetch();
     }
 
+    @Override
+    public List<User> findUsersWithNoJoyAchievementsForDays(final int days) {
+        final LocalDateTime dayCriteria = LocalDateTime.now().toLocalDate().atStartOfDay().minusDays(days);
 
+        return select(user)
+                .from(user)
+                .where(user.userId.notIn(
+                        JPAExpressions
+                                .select(achievement.achiever.userId)
+                                .from(achievement)
+                                .where(achievement.createdAt.after(dayCriteria))
+                ))
+                .distinct()
+                .fetch();
+    }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #157

## 📝 작업 내용
- 일주일 동안 소확행 실천하지 않은 유저 검색 쿼리 구현
- 알림 메시지 생성, 보내기, 저장을 담당하는 서비스 구현
