### PR TITLE
[Feature] 오플리 중복 개선

### DIFF
--- a/src/main/java/com/guttery/madii/common/exception/ErrorDetails.java
+++ b/src/main/java/com/guttery/madii/common/exception/ErrorDetails.java
@@ -60,6 +60,7 @@ public enum ErrorDetails {
     ACHIEVEMENT_NOT_FOUND("P001", HttpStatus.NOT_FOUND.value(), "오늘의 플레이리스트에서 해당 실천을 찾을 수 없습니다."),
     INVALID_SATISFACTION_ENUM("P002", HttpStatus.BAD_REQUEST.value(), "만족도 ENUM이 유효하지 않습니다. BAD, SO_SO, GOOD, GREAT, EXCELLENT 중 하나여야 합니다."),
     ACHIEVEMENT_ACHIEVER_NOT_MATCH("P003", HttpStatus.FORBIDDEN.value(), "해당 실천을 만든 사용자가 아닙니다."),
+    UNFINISHED_JOY_ALREADY_EXISTS_IN_PLAYLIST("P004", HttpStatus.CONFLICT.value(), "미완료 소확행이 이미 플레이리스트에 존재합니다."),
 
     FILE_UPLOAD_FAILED("F001", HttpStatus.INTERNAL_SERVER_ERROR.value(), "파일 업로드에 실패했습니다."),
 

--- a/src/main/java/com/guttery/madii/domain/achievement/application/service/AchievementServiceHelper.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/application/service/AchievementServiceHelper.java
@@ -4,6 +4,8 @@ import com.guttery.madii.common.exception.CustomException;
 import com.guttery.madii.common.exception.ErrorDetails;
 import com.guttery.madii.domain.achievement.domain.model.Achievement;
 import com.guttery.madii.domain.achievement.domain.repository.AchievementRepository;
+import com.guttery.madii.domain.joy.domain.model.Joy;
+import com.guttery.madii.domain.user.domain.model.User;
 import com.guttery.madii.domain.user.domain.model.UserPrincipal;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -26,5 +28,11 @@ public class AchievementServiceHelper {
         validateAchievementAchiever(foundAchievement, userPrincipal.id());
 
         return foundAchievement;
+    }
+
+    public static void validateUnfinishedJoyAchievementNotInPlaylist(final AchievementRepository achievementRepository, final Joy joy, final User achiever) {
+        if (achievementRepository.existsByJoyAndAchieverAndFinishInfo_IsFinishedFalse(joy, achiever)) {
+            throw CustomException.of(ErrorDetails.UNFINISHED_JOY_ALREADY_EXISTS_IN_PLAYLIST);
+        }
     }
 }

--- a/src/main/java/com/guttery/madii/domain/achievement/application/service/JoyPlaylistService.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/application/service/JoyPlaylistService.java
@@ -33,6 +33,7 @@ public class JoyPlaylistService {
         final User user = UserServiceHelper.findExistingUser(userRepository, userPrincipal);
         final Joy joy = JoyServiceHelper.findExistingJoy(joyRepository, addAchievementRequest.joyId());
         final Achievement newAchievement = Achievement.create(user, joy, FinishInfo.createNotFinished());
+        AchievementServiceHelper.validateUnfinishedJoyAchievementNotInPlaylist(achievementRepository, joy, user);
 
         achievementRepository.save(newAchievement);
     }
@@ -59,4 +60,5 @@ public class JoyPlaylistService {
         achievementRepository.delete(foundAchievement);
         achievementRepository.save(newAchievement);
     }
+
 }

--- a/src/main/java/com/guttery/madii/domain/achievement/domain/repository/AchievementQueryDslRepository.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/domain/repository/AchievementQueryDslRepository.java
@@ -15,5 +15,4 @@ public interface AchievementQueryDslRepository {
     CalenderDailyJoyAchievementResponse getDailyJoyAchievementInfos(Long userId, LocalDate date);
 
     Achievement getJoyAlreadyInPlaylist(Long userId, Long joyId, LocalDate date);
-
 }

--- a/src/main/java/com/guttery/madii/domain/achievement/domain/repository/AchievementRepository.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/domain/repository/AchievementRepository.java
@@ -1,7 +1,12 @@
 package com.guttery.madii.domain.achievement.domain.repository;
 
 import com.guttery.madii.domain.achievement.domain.model.Achievement;
+import com.guttery.madii.domain.joy.domain.model.Joy;
+import com.guttery.madii.domain.user.domain.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AchievementRepository extends JpaRepository<Achievement, Long>, AchievementQueryDslRepository {
+
+    boolean existsByJoyAndAchieverAndFinishInfo_IsFinishedFalse(Joy joy, User user);
+
 }

--- a/src/main/java/com/guttery/madii/domain/joy/domain/model/Joy.java
+++ b/src/main/java/com/guttery/madii/domain/joy/domain/model/Joy.java
@@ -1,11 +1,28 @@
 package com.guttery.madii.domain.joy.domain.model;
 
 import com.guttery.madii.common.domain.model.BaseTimeEntity;
+import com.guttery.madii.domain.albums.domain.model.SavingJoy;
 import com.guttery.madii.domain.user.domain.model.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,6 +41,8 @@ public class Joy extends BaseTimeEntity {
     private Integer joyIconNum; // 소확행 썸네일 아이콘 번호
     @Column(length = 30)
     private String contents; // 소확행 내용
+    @OneToMany(mappedBy = "joy", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SavingJoy> savingJoys;
 
     public Joy(User user, JoyType joyType, Integer joyIconNum, String contents) {
         this.user = user;


### PR DESCRIPTION
## 💡 연관된 이슈
close #180

## 📝 작업 내용
- 미완료 소확행이 이미 존재하는 경우 오플리에 추가되지 않도록 구현
