### PR TITLE
[Fix] 소확행 미실천 알림 문구 수정

### DIFF
--- a/src/main/java/com/guttery/madii/domain/notification/domain/model/Notification.java
+++ b/src/main/java/com/guttery/madii/domain/notification/domain/model/Notification.java
@@ -52,10 +52,10 @@ public class Notification {
                 .toList();
     }
 
-    public static List<Notification> createdBulkFormatted(List<User> users, String title, String formattedContents) {
+    public static List<Notification> createdBulkFormatted(List<User> users, String formattedTitle, String contents) {
         return users.stream()
                 .filter(User::hasProfile)
-                .map(user -> new Notification(user, title, String.format(formattedContents, user.getNickname()), false))
+                .map(user -> new Notification(user, String.format(formattedTitle, user.getNickname()), contents, false))
                 .toList();
     }
 


### PR DESCRIPTION
## 💡 연관된 이슈
close #185

## 📝 작업 내용
- String Format이 알림 제목이 아닌 내용에 들어가 있던 것 수정
