### PR TITLE
[Fix] 중복 체크할 때 현재 날짜 기준으로 하도록 변경

### DIFF
--- a/src/main/java/com/guttery/madii/domain/achievement/application/service/AchievementServiceHelper.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/application/service/AchievementServiceHelper.java
@@ -31,7 +31,7 @@ public class AchievementServiceHelper {
     }
 
     public static void validateUnfinishedJoyAchievementNotInPlaylist(final AchievementRepository achievementRepository, final Joy joy, final User achiever) {
-        if (achievementRepository.existsByJoyAndAchieverAndFinishInfo_IsFinishedFalse(joy, achiever)) {
+        if (achievementRepository.checkJoyAlreadyInPlaylist(joy, achiever)) {
             throw CustomException.of(ErrorDetails.UNFINISHED_JOY_ALREADY_EXISTS_IN_PLAYLIST);
         }
     }

--- a/src/main/java/com/guttery/madii/domain/achievement/domain/repository/AchievementQueryDslRepository.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/domain/repository/AchievementQueryDslRepository.java
@@ -3,7 +3,8 @@ package com.guttery.madii.domain.achievement.domain.repository;
 import com.guttery.madii.domain.achievement.application.dto.CalenderAchievementColorResponse;
 import com.guttery.madii.domain.achievement.application.dto.CalenderDailyJoyAchievementResponse;
 import com.guttery.madii.domain.achievement.application.dto.JoyPlaylistResponse;
-import com.guttery.madii.domain.achievement.domain.model.Achievement;
+import com.guttery.madii.domain.joy.domain.model.Joy;
+import com.guttery.madii.domain.user.domain.model.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,5 +16,5 @@ public interface AchievementQueryDslRepository {
 
     CalenderDailyJoyAchievementResponse getDailyJoyAchievementInfos(Long userId, LocalDate date);
 
-    Achievement getJoyAlreadyInPlaylist(Long userId, Long joyId, LocalDate date);
+    boolean checkJoyAlreadyInPlaylist(Joy joy, User achiever);
 }

--- a/src/main/java/com/guttery/madii/domain/achievement/infrastructure/AchievementRepositoryImpl.java
+++ b/src/main/java/com/guttery/madii/domain/achievement/infrastructure/AchievementRepositoryImpl.java
@@ -9,9 +9,10 @@ import com.guttery.madii.domain.achievement.application.dto.DailyJoyAchievementI
 import com.guttery.madii.domain.achievement.application.dto.DailyJoyPlaylist;
 import com.guttery.madii.domain.achievement.application.dto.JoyAchievementInfo;
 import com.guttery.madii.domain.achievement.application.dto.JoyPlaylistResponse;
-import com.guttery.madii.domain.achievement.domain.model.Achievement;
 import com.guttery.madii.domain.achievement.domain.repository.AchievementQueryDslRepository;
 import com.guttery.madii.domain.achievement.domain.repository.AchievementRepository;
+import com.guttery.madii.domain.joy.domain.model.Joy;
+import com.guttery.madii.domain.user.domain.model.User;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.StringExpression;
@@ -122,14 +123,16 @@ public class AchievementRepositoryImpl extends BaseQueryDslRepository<Achievemen
     }
 
     @Override
-    public Achievement getJoyAlreadyInPlaylist(Long userId, Long joyId, LocalDate date) {
+    public boolean checkJoyAlreadyInPlaylist(final Joy addedJoy, final User achiever) {
+        final LocalDate date = convertToLocalDateByOffset(LocalDateTime.now());
+
         return select(achievement)
                 .from(achievement)
                 .join(achievement.joy, joy)
                 .fetchJoin()
                 .join(achievement.achiever, user)
                 .fetchJoin()
-                .where(achievement.achiever.userId.eq(userId), joy.joyId.eq(joyId), achievement.createdAt.between(date.atStartOfDay().plusHours(TODAY_PLAYLIST_TIME_OFFSET), date.atStartOfDay().plusDays(1).minusSeconds(1).plusHours(TODAY_PLAYLIST_TIME_OFFSET)))
-                .fetchFirst();
+                .where(achievement.achiever.eq(user), joy.eq(addedJoy), achievement.finishInfo.isFinished.isFalse(), achievement.createdAt.between(date.atStartOfDay().plusHours(TODAY_PLAYLIST_TIME_OFFSET), date.atStartOfDay().plusDays(1).minusSeconds(1).plusHours(TODAY_PLAYLIST_TIME_OFFSET)))
+                .fetchFirst() != null;
     }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #194

## 📝 작업 내용
- 쿼리 에러 수정
