### PR TITLE
[Feature] 앨범 편집 API 기능 구현

### DIFF
--- a/src/main/java/com/guttery/madii/common/exception/ErrorDetails.java
+++ b/src/main/java/com/guttery/madii/common/exception/ErrorDetails.java
@@ -52,6 +52,7 @@ public enum ErrorDetails {
 
     JOY_NOT_FOUND("J001", HttpStatus.NOT_FOUND.value(), "소확행을 찾을 수 없습니다."),
     TODAY_JOY_NOT_FOUND("J100", HttpStatus.NOT_FOUND.value(), "오늘의 소확행을 찾을 수 없습니다."),
+    SAVING_JOY_NOT_FOUND("J001", HttpStatus.NOT_FOUND.value(), "앨범에 저장된 소확행 기록을 찾을 수 없습니다."),
 
     ALBUM_NOT_FOUND("A001", HttpStatus.NOT_FOUND.value(), "앨범을 찾을 수 없습니다."),
     ALREADY_EXIST_BOOKMARK("A002", HttpStatus.BAD_REQUEST.value(), "이미 저장한 앨범입니다."),

--- a/src/main/java/com/guttery/madii/domain/albums/application/dto/AlbumPutAllRequest.java
+++ b/src/main/java/com/guttery/madii/domain/albums/application/dto/AlbumPutAllRequest.java
@@ -1,0 +1,23 @@
+package com.guttery.madii.domain.albums.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "앨범 편집 요청")
+public record AlbumPutAllRequest(
+        @NotBlank(message = "앨범 제목은 필수입니다.")
+        @Schema(description = "앨범 제목", example = "겨울 필수 소확행 모음 zip")
+        @Size(max=30, message = "앨범 제목은 30자 이내로 입력해 주세요.")
+        String name,
+        @Schema(description = "앨범 내용", example = "이 소확행은 기분이 째질 때 츄라이해보면 좋은 소확행이에요.")
+        @Size(max=50, message = "앨범 내용은 50자 이내로 입력해 주세요.")
+        String description,
+        @Schema(description = "수정되거나 추가된 소확행 목록", example = "")
+        List<SavingJoyDto> joys,
+        @Schema(description = "삭제할 소확행 ID 목록", example = "")
+        List<Long> deletedJoyIds
+) {
+}

--- a/src/main/java/com/guttery/madii/domain/albums/application/dto/SavingJoyDto.java
+++ b/src/main/java/com/guttery/madii/domain/albums/application/dto/SavingJoyDto.java
@@ -1,0 +1,13 @@
+package com.guttery.madii.domain.albums.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SavingJoyDto(
+        @Schema(description = "소확행 아이디", example = "11")
+        Long joyId,
+        @Schema(description = "소확행 내용", example = "낮잠자기")
+        String contents,
+        @Schema(description = "소확행 정렬 순서", example = "3")
+        Integer joyOrder
+) {
+}

--- a/src/main/java/com/guttery/madii/domain/albums/domain/model/SavingJoy.java
+++ b/src/main/java/com/guttery/madii/domain/albums/domain/model/SavingJoy.java
@@ -31,11 +31,19 @@ public class SavingJoy extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "album_id", nullable = false)
     private Album album; // 앨범 id
+    private Integer joyOrder; // 소확행 정렬 순서
 
-    public SavingJoy(Joy joy, Album album) {
+    public SavingJoy(Joy joy, Album album, Integer joyOrder) {
         this.joy = joy;
         this.album = album;
+        this.joyOrder = joyOrder;
     }
 
-    public static SavingJoy createSavingJoy(Joy joy, Album album) { return new SavingJoy(joy, album); }
+    public static SavingJoy createSavingJoy(Joy joy, Album album, Integer joyOrder) {
+        return new SavingJoy(joy, album, joyOrder);
+    }
+
+    public void modifyJoyOrder(Integer joyOrder) {
+        this.joyOrder = joyOrder;
+    }
 }

--- a/src/main/java/com/guttery/madii/domain/albums/domain/repository/SavingJoyRepository.java
+++ b/src/main/java/com/guttery/madii/domain/albums/domain/repository/SavingJoyRepository.java
@@ -5,9 +5,17 @@ import com.guttery.madii.domain.albums.domain.model.SavingJoy;
 import com.guttery.madii.domain.joy.domain.model.Joy;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface SavingJoyRepository extends JpaRepository<SavingJoy, Long> {
 
-    SavingJoy findByJoyAndAlbum(Joy joy, Album album);
+    Optional<SavingJoy> findByJoyAndAlbum(Joy joy, Album album);
 
     void deleteByAlbumAlbumId(Long albumId);
+
+    Integer findMaxOrderByAlbum(Album album);
+
+    void deleteAllByJoyJoyIdIn(List<Long> deletedJoyIds);
+
 }

--- a/src/main/java/com/guttery/madii/domain/albums/presentation/AlbumController.java
+++ b/src/main/java/com/guttery/madii/domain/albums/presentation/AlbumController.java
@@ -280,4 +280,22 @@ public class AlbumController {
         albumService.reportAlbum(albumReportRequest, albumId, userPrincipal);
     }
 
+
+    @PutMapping("/{albumId}/all")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "앨범 편집 성공",
+                            useReturnTypeSchema = true
+                    )
+            }
+    )
+    @Operation(summary = "앨범 편집 API", description = "앨범 편집 API입니다.")
+    public void putAllAlbum(@Valid @RequestBody AlbumPutAllRequest albumPutAllRequest,
+                            @PathVariable Long albumId,
+                            @AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        albumService.putAllAlbum(albumPutAllRequest, albumId, userPrincipal);
+    }
+
 }

--- a/src/main/java/com/guttery/madii/domain/joy/application/service/JoyService.java
+++ b/src/main/java/com/guttery/madii/domain/joy/application/service/JoyService.java
@@ -65,7 +65,8 @@ public class JoyService {
                     .orElseThrow(() -> CustomException.of(ErrorDetails.JOY_NOT_FOUND));
             final Album album = albumRepository.findById(albumId)
                     .orElseThrow(() -> CustomException.of(ErrorDetails.ALBUM_NOT_FOUND));
-            final SavingJoy savingJoy = savingJoyRepository.findByJoyAndAlbum(joy, album);
+            final SavingJoy savingJoy = savingJoyRepository.findByJoyAndAlbum(joy, album)
+                    .orElseThrow(() -> CustomException.of(ErrorDetails.SAVING_JOY_NOT_FOUND));
             savingJoyRepository.delete(savingJoy);
         }
     }
@@ -76,7 +77,11 @@ public class JoyService {
                     .orElseThrow(() -> CustomException.of(ErrorDetails.JOY_NOT_FOUND));
             final Album album = albumRepository.findById(albumId)
                     .orElseThrow(() -> CustomException.of(ErrorDetails.ALBUM_NOT_FOUND));
-            final SavingJoy savingJoy = SavingJoy.createSavingJoy(joy, album);
+
+            // 앨범 내에서 가장 높은 order 값을 조회하여 1을 더해줌
+            Integer maxOrder = savingJoyRepository.findMaxOrderByAlbum(album);
+            Integer joyOrder = (maxOrder == null) ? 1 : maxOrder + 1;
+            final SavingJoy savingJoy = SavingJoy.createSavingJoy(joy, album, joyOrder);
             savingJoyRepository.save(savingJoy);
 
             // 앨범은 공개, 소확행은 비공개일 때 -> 소확행 공개로 변경

--- a/src/main/java/com/guttery/madii/domain/joy/domain/model/Joy.java
+++ b/src/main/java/com/guttery/madii/domain/joy/domain/model/Joy.java
@@ -58,6 +58,10 @@ public class Joy extends BaseTimeEntity {
         return new Joy(user, JoyType.PERSONAL, joyIconNum, contents);
     }
 
+    public static Joy createOfficialJoy(User user, Integer joyIconNum, String contents) {
+        return new Joy(user, JoyType.OFFICIAL, joyIconNum, contents);
+    }
+
     public void modifyContents(String contents) {
         this.contents = contents;
     }


### PR DESCRIPTION
## 💡 연관된 이슈
close #206 

## 📝 작업 내용
앨범 편집 API 기능 구현
- 앨범명/설명/소확행명 수정
- 소확행 순서 정렬 변경
  - saving_joy 테이블에 정렬 순서 저장하는 column 추가
  - 그에 따른 기존 데이터 joyOrder 세팅 (saving_joy_id 따라)
  - SavingJoy 엔티티 필드 추가
 - 기존 소확행 삭제
 - 새 소확행 추가

## 💬 리뷰 요구 사항
